### PR TITLE
[proprietary backport] imagedestroy() has no effect since 8.5

### DIFF
--- a/src/avatar/av.php
+++ b/src/avatar/av.php
@@ -102,12 +102,10 @@ foreach ($renderOrder as $layerName) {
         $height         // height
     );
     
-    imagedestroy($sourceImage);
 }
 
 // Save the final image
 $success = imagepng($finalImage, 'a/' . $_SESSION["username"] . '.png');
-imagedestroy($finalImage);
 
 if ($success) {
     echo "prompt:Avatar saved successfully!";


### PR DESCRIPTION
Remove all instances of imagedestroy().